### PR TITLE
Update to JIRA version 6.3.6

### DIFF
--- a/install-jira.sh
+++ b/install-jira.sh
@@ -7,7 +7,7 @@
 #	https://maxlab.polito.it/confluence/x/DAAb
 # ==================================================================================================
 
-set -x
+#set -x
 
 DOWNLOAD_DIR=`pwd`/tmp
 #DOWNLOAD_DIR=$/Downloads


### PR DESCRIPTION
Currently available at https://www.atlassian.com/software/jira/download

Should fix https://github.com/gmacario/vagrant-atlassian/issues/20

Signed-off-by: Gianpaolo Macario gmacario@gmail.com
